### PR TITLE
Security: Pin action SHAs and add explicit permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     name: PHP ${{ matrix.php }} - Symfony ${{ matrix.symfony }}
@@ -25,10 +28,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@d59004228537ca90c8dca680592a08a675bf52b6 # v2
         with:
           php-version: ${{ matrix.php }}
           extensions: mbstring, xml, ctype, iconv
@@ -42,7 +45,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache Composer packages
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-php-${{ matrix.php }}-symfony-${{ matrix.symfony }}-${{ hashFiles('**/composer.json') }}
@@ -65,10 +68,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@d59004228537ca90c8dca680592a08a675bf52b6 # v2
         with:
           php-version: '8.2'
           extensions: mbstring, xml, ctype, iconv
@@ -79,7 +82,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache Composer packages
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-php-8.2-composer-${{ hashFiles('**/composer.json') }}
@@ -101,10 +104,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@d59004228537ca90c8dca680592a08a675bf52b6 # v2
         with:
           php-version: '8.2'
           extensions: mbstring, xml, ctype, iconv
@@ -115,7 +118,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache Composer packages
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-php-8.2-composer-${{ hashFiles('**/composer.json') }}
@@ -129,7 +132,7 @@ jobs:
         run: vendor/bin/phpunit --coverage-text --coverage-clover=coverage.xml
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
         with:
           files: ./coverage.xml
           fail_ci_if_error: false


### PR DESCRIPTION
## Summary
This PR fixes GitHub Actions workflow security alerts by:
- Adding explicit `permissions` block with `contents: read` as minimum privilege
- Pinning ALL GitHub Actions to full commit SHAs (not tags/branches)

## Changes Made

### Permissions
- Added workflow-level `permissions: contents: read` block
- Follows principle of least privilege for security

### Action SHA Pinning
All actions are now pinned to immutable commit SHAs to prevent tag/branch hijacking:

- `actions/checkout@v4.2.2` → `actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683`
- `shivammathur/setup-php@v2` → `shivammathur/setup-php@d59004228537ca90c8dca680592a08a675bf52b6`
- `actions/cache@v4` → `actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830`
- `codecov/codecov-action@v4` → `codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238`

## Security Benefits

1. **Explicit Permissions**: Limits workflow permissions to only what's needed (read-only access to repository contents)
2. **Immutable Action Versions**: SHA pinning ensures actions cannot be modified via tag updates
3. **Supply Chain Security**: Protects against tag/branch hijacking attacks
4. **Audit Trail**: Full SHAs provide clear version tracking with comments showing original version tags

## Testing
- No functional changes to workflow logic
- All existing tests and jobs remain unchanged
- Only security hardening applied

## References
- [GitHub Security Best Practices](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions)
- [OpenSSF Scorecard Security Guidelines](https://github.com/ossf/scorecard)