### PR TITLE
chore(deps): allow Symfony 8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         php: ['8.4']
-        symfony: ['5.4.*', '6.4.*', '7.2.*']
+        symfony: ['5.4.*', '6.4.*', '7.2.*', '8.0.*']
 
     steps:
       - name: Checkout code

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A Composer plugin that enables universal AI agent skill distribution and managem
 [![Tests](https://img.shields.io/badge/tests-31%20passing-success)](tests/)
 [![PHPStan](https://img.shields.io/badge/PHPStan-level%208-success)](phpstan.neon)
 [![PHP Version](https://img.shields.io/badge/php-%5E8.2-blue)](composer.json)
-[![Symfony](https://img.shields.io/badge/symfony-5.4%20%7C%206.x%20%7C%207.x-blue)](composer.json)
+[![Symfony](https://img.shields.io/badge/symfony-5.4%20%7C%206.x%20%7C%207.x%20%7C%208.x-blue)](composer.json)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
 ## 🔌 Compatibility

--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,8 @@
   "require": {
     "php": "^8.4.1",
     "composer-plugin-api": "^2.1",
-    "symfony/yaml": "^5.4|^6.0|^7.0",
-    "symfony/console": "^5.4|^6.0|^7.0"
+    "symfony/yaml": "^5.4|^6.0|^7.0|^8.0",
+    "symfony/console": "^5.4|^6.0|^7.0|^8.0"
   },
   "require-dev": {
     "composer/composer": "^2.1",


### PR DESCRIPTION
## Summary
- Allow Symfony 8 for symfony/yaml and symfony/console while preserving existing Symfony 5.4, 6, and 7 compatibility.
- Add Symfony 8 to the CI compatibility matrix.