### PR TITLE
feat: support PHP 8.5, Symfony 8.0, and broaden Composer host matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,14 +12,22 @@ permissions:
 
 jobs:
   tests:
-    name: PHP ${{ matrix.php }} - Symfony ${{ matrix.symfony }}
+    name: PHP ${{ matrix.php }} - Symfony ${{ matrix.symfony }} - Composer ${{ matrix.composer }}${{ matrix.prefer-lowest && ' (lowest)' || '' }}
     runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
       matrix:
         php: ['8.4', '8.5']
-        symfony: ['5.4.*', '6.4.*', '7.2.*', '8.0.*']
+        symfony: ['5.4.*', '6.4.*', '7.4.*', '8.0.*']
+        composer: ['2.2', '2.9']
+        include:
+          # Validate declared dependency minimums (lowest stable resolution)
+          # against Composer LTS — catches under-constrained requires.
+          - php: '8.4'
+            symfony: '5.4.*'
+            composer: '2.2'
+            prefer-lowest: true
 
     steps:
       - name: Checkout code
@@ -29,6 +37,7 @@ jobs:
         uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2
         with:
           php-version: ${{ matrix.php }}
+          tools: composer:${{ matrix.composer }}
           extensions: mbstring, xml, ctype, iconv
           coverage: none
 
@@ -43,16 +52,21 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-php-${{ matrix.php }}-symfony-${{ matrix.symfony }}-${{ hashFiles('**/composer.json') }}
+          key: ${{ runner.os }}-php-${{ matrix.php }}-symfony-${{ matrix.symfony }}-composer-${{ matrix.composer }}-${{ matrix.prefer-lowest && 'low' || 'high' }}-${{ hashFiles('**/composer.json') }}
           restore-keys: |
+            ${{ runner.os }}-php-${{ matrix.php }}-symfony-${{ matrix.symfony }}-composer-${{ matrix.composer }}-
             ${{ runner.os }}-php-${{ matrix.php }}-symfony-${{ matrix.symfony }}-
             ${{ runner.os }}-php-${{ matrix.php }}-
             ${{ runner.os }}-php-
 
       - name: Install dependencies
+        env:
+          SYMFONY_VERSION: ${{ matrix.symfony }}
+          UPDATE_FLAGS: ${{ matrix.prefer-lowest && '--prefer-lowest --prefer-stable' || '' }}
         run: |
-          composer require "symfony/yaml:${{ matrix.symfony }}" "symfony/console:${{ matrix.symfony }}" --no-update --no-interaction
-          composer update --prefer-dist --no-progress
+          composer require "symfony/yaml:${SYMFONY_VERSION}" "symfony/console:${SYMFONY_VERSION}" --no-update --no-interaction
+          # shellcheck disable=SC2086
+          composer update --prefer-dist --no-progress ${UPDATE_FLAGS}
 
       - name: Run tests
         run: vendor/bin/phpunit --testdox

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['8.4']
-        symfony: ['5.4.*', '6.4.*', '7.2.*']
+        php: ['8.4', '8.5']
+        symfony: ['5.4.*', '6.4.*', '7.2.*', '8.0.*']
 
     steps:
       - name: Checkout code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **PHP 8.5 and Symfony 8.0 support** in the test matrix and Composer constraints (`symfony/yaml`, `symfony/console`).
 - **Symfony 7.4 LTS** added to the test matrix (replacing 7.2, which no longer receives security updates).
 - **Composer host matrix** — every PHP × Symfony combination is now tested against both Composer 2.2 LTS and 2.9 (the only supported Composer 2.x release lines).
-- **Lowest declared dependency** validation — one extra row resolves with `--prefer-lowest --prefer-stable` against Composer 2.2 LTS, ensuring documented minimums (`symfony/* ^5.4`, `composer-plugin-api ^2.1`) actually install and pass tests.
+- **Lowest declared dependency** validation — one extra row resolves with `--prefer-lowest --prefer-stable` against Composer 2.2 LTS, ensuring documented minimums actually install and pass tests.
+
+### Fixed
+- **Composer 2.2 LTS compatibility** — `CommandContextTrait` now falls back to the legacy `getComposer(false)` API on Composer 2.2; `tryComposer()` was only introduced in Composer 2.3. Detected by the new `--prefer-lowest` matrix row.
+
+### Changed
+- `composer-plugin-api` constraint changed from `^2.1` to `2.2.*|^2.9` — matches the only Composer release lines we test and the only ones that receive upstream support. Composer 2.0/2.1 are out of support; 2.3–2.8 are no longer maintained either.
+- `composer/composer` (require-dev) constraint changed from `^2.1` to `2.2.*|^2.9` for the same reason.
 - **Universal skill discovery**: any Composer package can now ship skills via `extra.ai-agent-skill`, regardless of its declared `type`. Closes [#42](https://github.com/netresearch/composer-agent-skill-plugin/issues/42).
 - **Trust prompt**: first-time discovery from a new package prompts the user (`y`/`n`/`a`/`d`) before registering its skills. Decisions persist in root `composer.json` under `extra.ai-agent-skill.allow-skills` with glob support, mirroring Composer's `config.allow-plugins`.
 - **First-run policy prompt** for legacy `type: ai-agent-skill` packages: `[n] None / [d] Direct deps only / [a] All`, default `n` (strict). Non-interactive mode defaults to `n` with a per-package `composer skills:trust ...` recovery hint, so CI never silently auto-trusts dependencies. Replaces the earlier prototype's "auto-seed everything" behavior flagged HIGH by the security review.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,13 +26,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Symfony 7.4 LTS** added to the test matrix (replacing 7.2, which no longer receives security updates).
 - **Composer host matrix** — every PHP × Symfony combination is now tested against both Composer 2.2 LTS and 2.9 (the only supported Composer 2.x release lines).
 - **Lowest declared dependency** validation — one extra row resolves with `--prefer-lowest --prefer-stable` against Composer 2.2 LTS, ensuring documented minimums actually install and pass tests.
-
-### Fixed
-- **Composer 2.2 LTS compatibility** — `CommandContextTrait` now falls back to the legacy `getComposer(false)` API on Composer 2.2; `tryComposer()` was only introduced in Composer 2.3. Detected by the new `--prefer-lowest` matrix row.
-
-### Changed
-- `composer-plugin-api` constraint changed from `^2.1` to `2.2.*|^2.9` — matches the only Composer release lines we test and the only ones that receive upstream support. Composer 2.0/2.1 are out of support; 2.3–2.8 are no longer maintained either.
-- `composer/composer` (require-dev) constraint changed from `^2.1` to `2.2.*|^2.9` for the same reason.
 - **Universal skill discovery**: any Composer package can now ship skills via `extra.ai-agent-skill`, regardless of its declared `type`. Closes [#42](https://github.com/netresearch/composer-agent-skill-plugin/issues/42).
 - **Trust prompt**: first-time discovery from a new package prompts the user (`y`/`n`/`a`/`d`) before registering its skills. Decisions persist in root `composer.json` under `extra.ai-agent-skill.allow-skills` with glob support, mirroring Composer's `config.allow-plugins`.
 - **First-run policy prompt** for legacy `type: ai-agent-skill` packages: `[n] None / [d] Direct deps only / [a] All`, default `n` (strict). Non-interactive mode defaults to `n` with a per-package `composer skills:trust ...` recovery hint, so CI never silently auto-trusts dependencies. Replaces the earlier prototype's "auto-seed everything" behavior flagged HIGH by the security review.
@@ -44,7 +37,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `composer read-skill` now shows trust state in the header and warns when reading content from a pending or denied skill (which is not registered in `AGENTS.md`).
 - `SkillTrustManager`, `PackageProvider`, `InstalledVersionsProvider`, `PackageInfo`, and `TrustDecision` abstractions for testability.
 
+### Fixed
+- **Composer 2.2 LTS compatibility** — `CommandContextTrait` now falls back to the legacy `getComposer(false)` API on Composer 2.2; `tryComposer()` was only introduced in Composer 2.3. Detected by the new `--prefer-lowest` matrix row.
+
 ### Changed
+- `composer-plugin-api` constraint changed from `^2.1` to `2.2.*|^2.9` — matches the only Composer release lines we test and the only ones that receive upstream support. Composer 2.0/2.1 are out of support; 2.3–2.8 are no longer maintained either.
+- `composer/composer` (require-dev) constraint changed from `^2.1` to `2.2.*|^2.9` for the same reason.
 - `SkillDiscovery` no longer filters by package `type`. Legacy `type: ai-agent-skill` packages with a root `SKILL.md` continue to work unchanged.
 - `SkillDiscovery::discoverAllSkills()` is now pure — it enumerates every declared skill with a `trust_state` field but never prompts. Gating happens at the install/update boundary in `SkillPlugin::updateAgentsMd()` only.
 - Non-interactive `composer install` now skips untrusted skill packages with a `composer config --json` hint instead of registering them silently.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > for the rationale.
 
 ### Added
-- **PHP 8.5 and Symfony 8.0 support** in the test matrix and Composer constraints (`symfony/yaml`, `symfony/console`). PHP 8.4 and Symfony 5.4/6.4/7.2 remain tested.
+- **PHP 8.5 and Symfony 8.0 support** in the test matrix and Composer constraints (`symfony/yaml`, `symfony/console`).
+- **Symfony 7.4 LTS** added to the test matrix (replacing 7.2, which no longer receives security updates).
+- **Composer host matrix** — every PHP × Symfony combination is now tested against both Composer 2.2 LTS and 2.9 (the only supported Composer 2.x release lines).
+- **Lowest declared dependency** validation — one extra row resolves with `--prefer-lowest --prefer-stable` against Composer 2.2 LTS, ensuring documented minimums (`symfony/* ^5.4`, `composer-plugin-api ^2.1`) actually install and pass tests.
 - **Universal skill discovery**: any Composer package can now ship skills via `extra.ai-agent-skill`, regardless of its declared `type`. Closes [#42](https://github.com/netresearch/composer-agent-skill-plugin/issues/42).
 - **Trust prompt**: first-time discovery from a new package prompts the user (`y`/`n`/`a`/`d`) before registering its skills. Decisions persist in root `composer.json` under `extra.ai-agent-skill.allow-skills` with glob support, mirroring Composer's `config.allow-plugins`.
 - **First-run policy prompt** for legacy `type: ai-agent-skill` packages: `[n] None / [d] Direct deps only / [a] All`, default `n` (strict). Non-interactive mode defaults to `n` with a per-package `composer skills:trust ...` recovery hint, so CI never silently auto-trusts dependencies. Replaces the earlier prototype's "auto-seed everything" behavior flagged HIGH by the security review.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > for the rationale.
 
 ### Added
+- **PHP 8.5 and Symfony 8.0 support** in the test matrix and Composer constraints (`symfony/yaml`, `symfony/console`). PHP 8.4 and Symfony 5.4/6.4/7.2 remain tested.
 - **Universal skill discovery**: any Composer package can now ship skills via `extra.ai-agent-skill`, regardless of its declared `type`. Closes [#42](https://github.com/netresearch/composer-agent-skill-plugin/issues/42).
 - **Trust prompt**: first-time discovery from a new package prompts the user (`y`/`n`/`a`/`d`) before registering its skills. Decisions persist in root `composer.json` under `extra.ai-agent-skill.allow-skills` with glob support, mirroring Composer's `config.allow-plugins`.
 - **First-run policy prompt** for legacy `type: ai-agent-skill` packages: `[n] None / [d] Direct deps only / [a] All`, default `n` (strict). Non-interactive mode defaults to `n` with a per-package `composer skills:trust ...` recovery hint, so CI never silently auto-trusts dependencies. Replaces the earlier prototype's "auto-seed everything" behavior flagged HIGH by the security review.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A Composer plugin that enables universal AI agent skill distribution and managem
 [![Tests](https://img.shields.io/badge/tests-31%20passing-success)](tests/)
 [![PHPStan](https://img.shields.io/badge/PHPStan-level%208-success)](phpstan.neon)
 [![PHP Version](https://img.shields.io/badge/php-%5E8.4-blue)](composer.json)
-[![Symfony](https://img.shields.io/badge/symfony-5.4%20%7C%206.x%20%7C%207.x%20%7C%208.x-blue)](composer.json)
+[![Symfony](https://img.shields.io/badge/symfony-5.4%20%7C%206.4%20%7C%207.4%20%7C%208.0-blue)](composer.json)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
 ## 🔌 Compatibility

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 A Composer plugin that enables universal AI agent skill distribution and management for PHP projects. Automatically discovers, registers, and manages AI agent skills from Composer packages, providing a standardized way for the PHP ecosystem to share agent capabilities.
 
 [![CI](https://github.com/netresearch/composer-agent-skill-plugin/actions/workflows/ci.yml/badge.svg)](https://github.com/netresearch/composer-agent-skill-plugin/actions/workflows/ci.yml)
-[![Tests](https://img.shields.io/badge/tests-31%20passing-success)](tests/)
-[![PHPStan](https://img.shields.io/badge/PHPStan-level%208-success)](phpstan.neon)
+[![Tests](https://img.shields.io/badge/tests-127%20passing-success)](tests/)
+[![PHPStan](https://img.shields.io/badge/PHPStan-level%2010%20(max)-success)](phpstan.neon)
 [![PHP Version](https://img.shields.io/badge/php-%5E8.4-blue)](composer.json)
 [![Symfony](https://img.shields.io/badge/symfony-5.4%20%7C%206.4%20%7C%207.4%20%7C%208.0-blue)](composer.json)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)

--- a/README.md
+++ b/README.md
@@ -9,19 +9,6 @@ A Composer plugin that enables universal AI agent skill distribution and managem
 [![Symfony](https://img.shields.io/badge/symfony-5.4%20%7C%206.4%20%7C%207.4%20%7C%208.0-blue)](composer.json)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
-## 🔌 Compatibility
-
-This is an **Agent Skill** following the [open standard](https://agentskills.io) originally developed by Anthropic and released for cross-platform use.
-
-**Supported Platforms:**
-- ✅ Claude Code (Anthropic)
-- ✅ Cursor
-- ✅ GitHub Copilot
-- ✅ Other skills-compatible AI agents
-
-> Skills are portable packages of procedural knowledge that work across any AI agent supporting the Agent Skills specification.
-
-
 ## Features
 
 - **Automatic Discovery**: Finds all packages with type `ai-agent-skill`

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ A Composer plugin that enables universal AI agent skill distribution and managem
 [![CI](https://github.com/netresearch/composer-agent-skill-plugin/actions/workflows/ci.yml/badge.svg)](https://github.com/netresearch/composer-agent-skill-plugin/actions/workflows/ci.yml)
 [![Tests](https://img.shields.io/badge/tests-31%20passing-success)](tests/)
 [![PHPStan](https://img.shields.io/badge/PHPStan-level%208-success)](phpstan.neon)
-[![PHP Version](https://img.shields.io/badge/php-%5E8.2-blue)](composer.json)
-[![Symfony](https://img.shields.io/badge/symfony-5.4%20%7C%206.x%20%7C%207.x-blue)](composer.json)
+[![PHP Version](https://img.shields.io/badge/php-%5E8.4-blue)](composer.json)
+[![Symfony](https://img.shields.io/badge/symfony-5.4%20%7C%206.x%20%7C%207.x%20%7C%208.x-blue)](composer.json)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
 ## 🔌 Compatibility

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     }
   ],
   "require": {
-    "php": "^8.4.1",
+    "php": "^8.4",
     "composer-plugin-api": "2.2.*|^2.9",
     "symfony/yaml": "^5.4|^6.0|^7.0|^8.0",
     "symfony/console": "^5.4|^6.0|^7.0|^8.0"

--- a/composer.json
+++ b/composer.json
@@ -13,12 +13,12 @@
   ],
   "require": {
     "php": "^8.4.1",
-    "composer-plugin-api": "^2.1",
+    "composer-plugin-api": "2.2.*|^2.9",
     "symfony/yaml": "^5.4|^6.0|^7.0|^8.0",
     "symfony/console": "^5.4|^6.0|^7.0|^8.0"
   },
   "require-dev": {
-    "composer/composer": "^2.1",
+    "composer/composer": "2.2.*|^2.9",
     "phpunit/phpunit": "^13.0",
     "phpstan/phpstan": "^2.0",
     "phpstan/extension-installer": "^1.3"

--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,8 @@
   "require": {
     "php": "^8.4.1",
     "composer-plugin-api": "^2.1",
-    "symfony/yaml": "^5.4|^6.0|^7.0",
-    "symfony/console": "^5.4|^6.0|^7.0"
+    "symfony/yaml": "^5.4|^6.0|^7.0|^8.0",
+    "symfony/console": "^5.4|^6.0|^7.0|^8.0"
   },
   "require-dev": {
     "composer/composer": "^2.1",

--- a/src/Commands/CommandContextTrait.php
+++ b/src/Commands/CommandContextTrait.php
@@ -12,8 +12,9 @@ namespace Netresearch\ComposerAgentSkillPlugin\Commands;
  * through to the cwd path; production paths use Composer's ConfigSource so
  * they honor `--working-dir`.
  *
- * Mixed into commands that extend {@see \Composer\Command\BaseCommand}, which
- * exposes the `tryComposer()` lookup we depend on.
+ * Mixed into commands that extend {@see \Composer\Command\BaseCommand}.
+ * `tryComposer()` was added in Composer 2.3; on 2.2 LTS we fall back to
+ * the legacy `getComposer(false)` (still present, deprecated since 2.3).
  *
  * @phpstan-require-extends \Composer\Command\BaseCommand
  */
@@ -26,7 +27,15 @@ trait CommandContextTrait
      */
     private function resolveContext(): array
     {
-        $composer = $this->tryComposer();
+        // tryComposer() was introduced in Composer 2.3; 2.2 LTS only has
+        // the deprecated getComposer(). Resolve in a way that works on both.
+        /** @phpstan-ignore-next-line function.alreadyNarrowedType */
+        if (method_exists($this, 'tryComposer')) {
+            $composer = $this->tryComposer();
+        } else {
+            /** @phpstan-ignore-next-line method.deprecated */
+            $composer = $this->getComposer(false);
+        }
         if ($composer !== null) {
             return [
                 $composer->getConfig()->getConfigSource()->getName(),

--- a/tests/Integration/ListSkillsCommandTest.php
+++ b/tests/Integration/ListSkillsCommandTest.php
@@ -10,12 +10,15 @@ use Netresearch\ComposerAgentSkillPlugin\Commands\ListSkillsCommand;
 use Netresearch\ComposerAgentSkillPlugin\Package\PackageInfo;
 use Netresearch\ComposerAgentSkillPlugin\Package\PackageProvider;
 use Netresearch\ComposerAgentSkillPlugin\SkillDiscovery;
+use Netresearch\ComposerAgentSkillPlugin\Tests\Support\RegistersConsoleCommands;
 use Netresearch\ComposerAgentSkillPlugin\Trust\SkillTrustManager;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Tester\CommandTester;
 
 final class ListSkillsCommandTest extends TestCase
 {
+    use RegistersConsoleCommands;
+
     private string $rootDir;
 
     protected function setUp(): void
@@ -62,7 +65,7 @@ final class ListSkillsCommandTest extends TestCase
 
         $command = new ListSkillsCommand($discovery);
         $app = new Application();
-        $app->add($command);
+        self::registerCommand($app, $command);
         $tester = new CommandTester($command);
         $tester->execute([]);
 
@@ -96,7 +99,7 @@ final class ListSkillsCommandTest extends TestCase
 
         $command = new ListSkillsCommand($discovery);
         $app = new Application();
-        $app->add($command);
+        self::registerCommand($app, $command);
         $tester = new CommandTester($command);
         $tester->execute([]);
         $output = $tester->getDisplay();

--- a/tests/Integration/ListTrustCommandTest.php
+++ b/tests/Integration/ListTrustCommandTest.php
@@ -6,11 +6,14 @@ namespace Netresearch\ComposerAgentSkillPlugin\Tests\Integration;
 
 use Composer\Console\Application;
 use Netresearch\ComposerAgentSkillPlugin\Commands\ListTrustCommand;
+use Netresearch\ComposerAgentSkillPlugin\Tests\Support\RegistersConsoleCommands;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Tester\CommandTester;
 
 final class ListTrustCommandTest extends TestCase
 {
+    use RegistersConsoleCommands;
+
     private string $rootDir;
     private string $cwdBackup;
 
@@ -44,7 +47,7 @@ final class ListTrustCommandTest extends TestCase
         file_put_contents($this->rootDir . '/composer.json', "{\n}\n");
 
         $command = new ListTrustCommand();
-        (new Application())->add($command);
+        self::registerCommand(new Application(), $command);
         $tester = new CommandTester($command);
         $tester->execute([]);
 
@@ -63,7 +66,7 @@ final class ListTrustCommandTest extends TestCase
         ], JSON_PRETTY_PRINT));
 
         $command = new ListTrustCommand();
-        (new Application())->add($command);
+        self::registerCommand(new Application(), $command);
         $tester = new CommandTester($command);
         $tester->execute([]);
 

--- a/tests/Integration/TrustSkillCommandTest.php
+++ b/tests/Integration/TrustSkillCommandTest.php
@@ -6,11 +6,14 @@ namespace Netresearch\ComposerAgentSkillPlugin\Tests\Integration;
 
 use Composer\Console\Application;
 use Netresearch\ComposerAgentSkillPlugin\Commands\TrustSkillCommand;
+use Netresearch\ComposerAgentSkillPlugin\Tests\Support\RegistersConsoleCommands;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Tester\CommandTester;
 
 final class TrustSkillCommandTest extends TestCase
 {
+    use RegistersConsoleCommands;
+
     private string $rootDir;
     private string $cwdBackup;
 
@@ -44,7 +47,7 @@ final class TrustSkillCommandTest extends TestCase
     {
         $command = new TrustSkillCommand();
         $app = new Application();
-        $app->add($command);
+        self::registerCommand($app, $command);
         $tester = new CommandTester($command);
 
         $exit = $tester->execute(['package' => 'vendor/foo']);
@@ -59,7 +62,7 @@ final class TrustSkillCommandTest extends TestCase
     {
         $command = new TrustSkillCommand();
         $app = new Application();
-        $app->add($command);
+        self::registerCommand($app, $command);
         $tester = new CommandTester($command);
 
         $exit = $tester->execute(['package' => 'vendor/bar', '--deny' => true]);
@@ -81,7 +84,7 @@ final class TrustSkillCommandTest extends TestCase
 
         $command = new TrustSkillCommand();
         $app = new Application();
-        $app->add($command);
+        self::registerCommand($app, $command);
         $tester = new CommandTester($command);
 
         $exit = $tester->execute(['package' => 'vendor/foo', '--revoke' => true]);
@@ -97,7 +100,7 @@ final class TrustSkillCommandTest extends TestCase
     {
         $command = new TrustSkillCommand();
         $app = new Application();
-        $app->add($command);
+        self::registerCommand($app, $command);
         $tester = new CommandTester($command);
 
         $exit = $tester->execute(['package' => 'evil/*; rm -rf']);
@@ -113,7 +116,7 @@ final class TrustSkillCommandTest extends TestCase
     {
         $command = new TrustSkillCommand();
         $app = new Application();
-        $app->add($command);
+        self::registerCommand($app, $command);
         $tester = new CommandTester($command);
 
         $exit = $tester->execute(['package' => 'Vendor/Foo']);
@@ -126,7 +129,7 @@ final class TrustSkillCommandTest extends TestCase
     {
         $command = new TrustSkillCommand();
         $app = new Application();
-        $app->add($command);
+        self::registerCommand($app, $command);
         $tester = new CommandTester($command);
 
         $exit = $tester->execute(['package' => 'vendor/*']);
@@ -140,7 +143,7 @@ final class TrustSkillCommandTest extends TestCase
     {
         $command = new TrustSkillCommand();
         $app = new Application();
-        $app->add($command);
+        self::registerCommand($app, $command);
         $tester = new CommandTester($command);
 
         $exit = $tester->execute(['package' => 'vendor/foo', '--deny' => true, '--revoke' => true]);

--- a/tests/Support/RegistersConsoleCommands.php
+++ b/tests/Support/RegistersConsoleCommands.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Netresearch\ComposerAgentSkillPlugin\Tests\Support;
+
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Command\Command;
+
+/**
+ * Bridge for Symfony Console's command-registration API across versions.
+ * Symfony 7.4 deprecated Application::add() in favour of Application::addCommand();
+ * Symfony 8.0 removed add() entirely.
+ */
+trait RegistersConsoleCommands
+{
+    private static function registerCommand(Application $app, Command $command): void
+    {
+        if (method_exists($app, 'addCommand')) {
+            $app->addCommand($command);
+            return;
+        }
+
+        /** @phpstan-ignore-next-line method.deprecated */
+        $app->add($command);
+    }
+}


### PR DESCRIPTION
## Summary

Expands what we promise to work on, and tightens what we promise to test.

### Added

- **PHP 8.5** added to the matrix (8.4 stays).
- **Symfony 8.0** added to constraints (`symfony/yaml`, `symfony/console`) and to the matrix.
- **Symfony 7.4 LTS** added; Symfony 7.2 dropped (no longer receives security updates per [symfony.com/releases](https://symfony.com/releases)).
- **Composer host matrix** — every PHP × Symfony cell runs against both **Composer 2.2 LTS** and **Composer 2.9** (the only Composer 2.x lines that receive upstream support).
- **Lowest-deps row** — one extra job resolves with `--prefer-lowest --prefer-stable` against Composer 2.2 LTS to verify documented dependency minimums actually install and pass tests.

Total: **17 CI jobs** (16 base + 1 lowest).

### Fixed

- **Composer 2.2 LTS compatibility** — `CommandContextTrait::resolveContext()` called `BaseCommand::tryComposer()`, which was only introduced in Composer 2.3. Real users on 2.2 LTS would hit a fatal `undefined method`. Now falls back to the legacy `getComposer(false)` (present since 2.0). Caught by the new `--prefer-lowest` row, not by the regular Composer 2.2 cells — those load `BaseCommand` from `vendor/composer/composer/` (latest) rather than the host.

### Changed

- `composer-plugin-api` constraint: `^2.1` → `2.2.*|^2.9`. Excludes 2.0/2.1 (out of support) and 2.3–2.8 (also no longer maintained); matches exactly what we test.
- `composer/composer` (require-dev): same change for the same reason.

### Tooling / cross-version test compat

- Symfony 7.4 deprecated `Application::add()` and 8.0 removed it (in favour of `addCommand()`). 11 integration test sites used the old API. Introduced `RegistersConsoleCommands` trait that picks `addCommand()` when present and falls back to `add()` for 5.4–7.3.

## Test plan

| | Symfony 5.4 | Symfony 6.4 | Symfony 7.4 | Symfony 8.0 |
|---|---|---|---|---|
| **PHP 8.4 / Composer 2.2** | ✅ | ✅ | ✅ | ✅ |
| **PHP 8.4 / Composer 2.9** | ✅ | ✅ | ✅ | ✅ |
| **PHP 8.5 / Composer 2.2** | ✅ | ✅ | ✅ | ✅ |
| **PHP 8.5 / Composer 2.9** | ✅ | ✅ | ✅ | ✅ |
| **Lowest deps (8.4 / 5.4 / 2.2)** | ✅ | — | — | — |

Plus Code Quality (PHPStan max), Code Coverage, CodeQL, Analyze — all green.

## Out of scope (flagged for separate work)

- `docs/PRD.md` lines 590-615 reference `php: ^8.1`, `symfony: ^6.0|^7.0`, and `composer-plugin-api: ^2.1`. These were already stale before this PR (the floor moved to PHP 8.4 some time ago). The canonical source is `composer.json`; aligning the PRD is its own cleanup.