### PR TITLE
chore: release v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+### Changed
+
+### Fixed
+
+## [2.0.0] - 2026-05-01
+
 ### Breaking changes
 
 > **First-run trust default changed from "auto-trust everything" to "deny by default".**
@@ -47,6 +55,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `SkillDiscovery::discoverAllSkills()` is now pure — it enumerates every declared skill with a `trust_state` field but never prompts. Gating happens at the install/update boundary in `SkillPlugin::updateAgentsMd()` only.
 - Non-interactive `composer install` now skips untrusted skill packages with a `composer config --json` hint instead of registering them silently.
 - PHPStan level bumped from 8 to 10 (max).
+
+## [1.1.5] - 2026-04-20
+
+### Changed
+- Dependency updates via Renovate: `step-security/harden-runner` v2.17.0–2.19.0, `actions/cache` digest refresh, `dependabot/fetch-metadata` v3.x, `codecov/codecov-action` v6.
+
+## [1.1.4] - 2026-03-20
+
+### Security
+- **GitHub Actions hardening** ([#31](https://github.com/netresearch/composer-agent-skill-plugin/pull/31)): SHA-pin all third-party actions and add Dependabot for the `github-actions` ecosystem so action updates ship as reviewable PRs rather than floating tags.
+
+### Changed
+- Dependency updates via Renovate: `step-security/harden-runner` v2.15.0–v2.16.0, `shivammathur/setup-php` digest refresh, `codecov/codecov-action` digest refresh.
+
+## [1.1.3] - 2026-02-09
+
+### Added
+- **"Agent Skills" branding and cross-platform compatibility** ([#10](https://github.com/netresearch/composer-agent-skill-plugin/pull/10)).
+- **Auto-merge workflow** for vetted dependency updates.
+- **Renovate** configuration ([#1](https://github.com/netresearch/composer-agent-skill-plugin/pull/1)).
+
+### Security
+- **Pinned GitHub Actions to commit SHAs** with explicit per-job permissions ([#2](https://github.com/netresearch/composer-agent-skill-plugin/pull/2)).
+
+### Changed
+- **PHPUnit upgraded to v13** ([#21](https://github.com/netresearch/composer-agent-skill-plugin/pull/21)) — breaking-change adaptations in the test suite.
+- Multiple Renovate-driven action and digest updates: `step-security/harden-runner` v2.14.0–2.14.2, `actions/checkout` v6.0.2, `actions/cache` digest refreshes, `dependabot/fetch-metadata` v2.5.0.
 
 ## [1.1.2] - 2025-11-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,7 +67,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **GitHub Actions hardening** ([#31](https://github.com/netresearch/composer-agent-skill-plugin/pull/31)): SHA-pin all third-party actions and add Dependabot for the `github-actions` ecosystem so action updates ship as reviewable PRs rather than floating tags.
 
 ### Changed
-- Dependency updates via Renovate: `step-security/harden-runner` v2.15.0–v2.16.0, `shivammathur/setup-php` digest refresh, `codecov/codecov-action` digest refresh.
+- Dependency updates via Renovate: `step-security/harden-runner` v2.15.0–2.16.0, `shivammathur/setup-php` digest refresh, `codecov/codecov-action` digest refresh.
 
 ## [1.1.3] - 2026-02-09
 
@@ -159,7 +159,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Path Traversal Protection**: Uses `realpath()` to resolve canonical paths
 - **XML Escaping**: Properly escapes skill metadata in generated XML
 
-[Unreleased]: https://github.com/netresearch/composer-agent-skill-plugin/compare/v1.1.2...HEAD
+[Unreleased]: https://github.com/netresearch/composer-agent-skill-plugin/compare/v2.0.0...HEAD
+[2.0.0]: https://github.com/netresearch/composer-agent-skill-plugin/compare/v1.1.5...v2.0.0
+[1.1.5]: https://github.com/netresearch/composer-agent-skill-plugin/compare/v1.1.4...v1.1.5
+[1.1.4]: https://github.com/netresearch/composer-agent-skill-plugin/compare/v1.1.3...v1.1.4
+[1.1.3]: https://github.com/netresearch/composer-agent-skill-plugin/compare/v1.1.2...v1.1.3
 [1.1.2]: https://github.com/netresearch/composer-agent-skill-plugin/compare/v1.1.1...v1.1.2
 [1.1.1]: https://github.com/netresearch/composer-agent-skill-plugin/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/netresearch/composer-agent-skill-plugin/compare/v1.0.0...v1.1.0


### PR DESCRIPTION
## Summary

Release **v2.0.0** — first major version.

This release ships universal skill discovery + a deny-by-default trust model, broadens the test matrix to PHP 8.5 / Symfony 8.0 / Composer 2.9, and adds Composer 2.2 LTS compatibility on the lowest-supported end. Two SemVer-major triggers: the first-run trust default flipped from auto-trust → deny-by-default, and `composer-plugin-api` narrowed from `^2.1` to `2.2.*|^2.9`.

This PR also backfills [1.1.3], [1.1.4], and [1.1.5] CHANGELOG entries that were tagged in git but never recorded.

## Changes

- `CHANGELOG.md`:
  - `[Unreleased]` → `[2.0.0] - 2026-05-01`
  - Fresh empty `[Unreleased]` scaffold added
  - Retroactive entries for `[1.1.3]` (PHPUnit v13, Agent Skills branding, action SHA pinning, Renovate), `[1.1.4]` (supply-chain hardening), `[1.1.5]` (dependency updates)

No code changes — `composer.json` carries no `version` field by Composer convention; the tag drives the version.

## Test plan

- [x] Working tree clean before commit
- [x] CI green on `main` HEAD (commit 60e6ea3)
- [x] Commit is signed (ED25519) and signed-off
- [ ] CI passes on this PR
- [ ] After merge: signed annotated tag `v2.0.0` pushed
- [ ] GitHub Release published manually (no `release.yml` workflow exists in this repo)

## Notes

- **No `release.yml` workflow** in this repo, so the GitHub Release will be created manually via `gh release create v2.0.0` after the tag is pushed.
- Two pre-existing lightweight tags (`v1.1.3`, `v1.1.5`) remain untouched — they cannot be safely fixed retroactively without breaking consumers. v2.0.0 is a proper signed annotated tag.