### PR TITLE
ci: add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,8 +23,12 @@ permissions: {}
 
 jobs:
   release:
-    uses: netresearch/.github/.github/workflows/release-composer-package.yml@main
+    uses: netresearch/.github/.github/workflows/release-composer-package.yml@2c6869a6c4c3ed1afad61569fc587e32b6b7a4db # main
     permissions:
       contents: write
     with:
-      tag: ${{ inputs.tag }}
+      # `inputs.tag` is only populated by workflow_dispatch; on tag-push the
+      # `inputs` context is empty, so we fall back to `github.ref_name` (the
+      # pushed tag). This makes the contract explicit at the caller boundary
+      # instead of relying on the reusable workflow's empty-string fallback.
+      tag: ${{ inputs.tag || github.ref_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+name: Release
+
+# Triggered by signed-tag push (`v*`). Delegates the entire release to the
+# org's `release-composer-package` reusable workflow, which validates the
+# tag (semver, annotated/signed), validates `composer.json`, and creates
+# the GitHub Release atomically with auto-generated notes.
+#
+# Packagist syncs the new version via webhook on tag push, independent of
+# this workflow.
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to release (e.g. v2.1.0). Used for backfills."
+        required: true
+        type: string
+
+permissions: {}
+
+jobs:
+  release:
+    uses: netresearch/.github/.github/workflows/release-composer-package.yml@main
+    permissions:
+      contents: write
+    with:
+      tag: ${{ inputs.tag }}


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/release.yml` — delegates to the org's [`release-composer-package`](https://github.com/netresearch/.github/blob/main/.github/workflows/release-composer-package.yml) reusable workflow ([introduced in netresearch/.github#124](https://github.com/netresearch/.github/pull/124)).
- Closes the missing-release-infrastructure gap flagged by the github-release skill's pre-release validation: v1.x and v2.0.0 were published manually because no automated release workflow existed.

## What the reusable workflow does

On signed-tag push (`v*`):

1. **Tag validation** — strict semver gate (`v<MAJOR>.<MINOR>.<PATCH>[-pre][+build]`), reject lightweight tags
2. **`composer validate --strict --no-check-publish`** — catch malformed `composer.json` before Packagist sees it
3. **Prerelease auto-detect** — from `-rc` / `-alpha` / `-beta` / `-pre` suffix
4. **`make-latest` auto-compute** — by comparing against existing non-draft non-prerelease semver releases via the GH API
5. **Atomic release create** — single `softprops/action-gh-release@v3` call with `generate_release_notes: true`, no post-creation edits

Packagist syncs the new version via its existing webhook on tag push, independent of this workflow.

## workflow_dispatch backfill

Also enables `workflow_dispatch` with a `tag` input, so a release entry can be re-created for an existing tag (e.g. v2.0.0 if you ever want a structured release entry for it) without re-tagging.

## Test plan

- [ ] PR CI passes (lint workflows, lint markdown, etc.)
- [ ] First real test: the upcoming v2.1.0 tag (separate follow-up PR will land the CHANGELOG bump)
- [ ] Verify the release workflow fires on tag push, runs to green, creates a GitHub Release with auto-generated notes