### PR TITLE
chore: release v2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
+### Fixed
+
+## [2.1.0] - 2026-05-12
+
+### Added
+
 - **`composer outdated` + direct skills** — after Composer’s package table (text mode), lists direct skills whose lock pin lags **`git ls-remote`** or local path content; JSON mode keeps package JSON valid and points to **`composer skills:outdated -f json`**. New command **`composer skills:outdated`** (`--strict` for CI exit 1).
 - **Semver constraints on GitHub refs** — `owner/repo:^1.2` or `--ref='^1.2'` resolves to the highest remote **tag** matching the constraint (`composer/semver` + `git ls-remote --tags`); **`composer update`** re-resolves and refreshes **`composer.skills.lock`** while **`composer install`** keeps the pinned commit.
 - **Direct skill installation** — declare sources under `extra.ai-agent-skills`, pin them in **`composer.skills.lock`**, and materialize trees under `install-dir` (default `vendor/agent-skills/installed/`). CLI: **`composer skills`** dispatcher with **`skills:add`**, `skills:install`, `skills:update`, `skills:remove`, `skills:list` (see README, `docs/IMPLEMENTATION-DIRECT-SKILLS.md`, ADRs 009–012).
@@ -170,7 +178,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Path Traversal Protection**: Uses `realpath()` to resolve canonical paths
 - **XML Escaping**: Properly escapes skill metadata in generated XML
 
-[Unreleased]: https://github.com/netresearch/composer-agent-skill-plugin/compare/v2.0.0...HEAD
+[Unreleased]: https://github.com/netresearch/composer-agent-skill-plugin/compare/v2.1.0...HEAD
+[2.1.0]: https://github.com/netresearch/composer-agent-skill-plugin/compare/v2.0.0...v2.1.0
 [2.0.0]: https://github.com/netresearch/composer-agent-skill-plugin/compare/v1.1.5...v2.0.0
 [1.1.5]: https://github.com/netresearch/composer-agent-skill-plugin/compare/v1.1.4...v1.1.5
 [1.1.4]: https://github.com/netresearch/composer-agent-skill-plugin/compare/v1.1.3...v1.1.4


### PR DESCRIPTION
## Summary

Promotes the `[Unreleased]` CHANGELOG section to `[2.1.0] - 2026-05-12` and opens a new empty `[Unreleased]` block.

Composer plugins read their version from the git tag, so no `composer.json` bump is needed.

## Changes shipped in v2.1.0

Full detail in [CHANGELOG.md](./CHANGELOG.md). Headlines:

- **Direct skill installation** from Git/local paths without Composer packages — declare under `extra.ai-agent-skills`, pin in `composer.skills.lock`, materialize under `vendor/agent-skills/installed/`
- **`composer skills` command tree**: `skills:add`, `skills:install`, `skills:update`, `skills:remove`, `skills:list`, `skills:outdated`
- **Semver constraints on git tag refs** (`owner/repo:^1.2`) via `composer/semver` + `git ls-remote --tags`
- **`composer outdated` integration** for stale direct skills (text + JSON modes); new `composer skills:outdated --strict` for CI
- **Direct-skills security hardening**: reject symlinks when copying/hashing, validate `composer.skills.lock` commits as 40-char hex, validate clone/tag refs, strict project-root prefix
- **`DiscoveredSkills`** helper, **`FilesystemUtil`** helper

## SemVer rationale

**Minor**, not major. Everything in `[Unreleased]` was `Added` or `Fixed`. No `Breaking changes` section. The new features sit on a separate config key (`extra.ai-agent-skills`) from the existing trust config (`extra.ai-agent-skill`); existing package-based users see no behavior change.

## Test plan

- [x] Pre-release validation (CHANGELOG content, working tree, signing, semver gate) — passed
- [x] Release infrastructure landed in [#49](https://github.com/netresearch/composer-agent-skill-plugin/pull/49)
- [ ] PR CI passes
- [ ] After merge: tag `v2.1.0` (signed) from `main` HEAD, push tag, watch the release workflow create the GitHub Release

## Post-merge tagging

```bash
git checkout main && git pull
git tag -s v2.1.0 -m "v2.1.0"
git push origin v2.1.0
```