### PR TITLE
ci: clear GitHub auth for the network test step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,17 @@ jobs:
         env:
           # Set to 1 only in air-gapped environments; default runs live clone tests.
           SKIP_NETWORK_TESTS: ${{ vars.SKIP_NETWORK_TESTS }}
-        run: vendor/bin/phpunit --testdox
+          # The @group network tests clone PUBLIC repos and need no GitHub auth.
+          # Clear any configured token so the composer/composer 2.2.0 library
+          # (installed in the prefer-lowest cell) does not reject the modern
+          # GitHub token format with "github oauth token … contains invalid
+          # characters". The composer binary is unaffected — this only concerns
+          # the library instantiated by the tests.
+          COMPOSER_AUTH: "{}"
+          GITHUB_TOKEN: ""
+        run: |
+          composer config --global --unset github-oauth.github.com 2>/dev/null || true
+          vendor/bin/phpunit --testdox
 
   code-quality:
     name: Code Quality


### PR DESCRIPTION
## Summary

Fixes the long-standing failure on the **PHP 8.4 · Symfony 5.4 · Composer 2.2 (lowest)** matrix cell:

```
UnexpectedValueException: Your github oauth token for github.com contains invalid characters: "***"
```

### Root cause

The `@group network` Integration tests instantiate Composer's `Application` from the **`composer/composer` library**, not the `composer` binary. Under `--prefer-lowest` that library resolves to **2.2.0**, whose GitHub OAuth token validation rejects the modern token format `setup-php` configures — so every Integration test that drives Composer errors. It is deterministic on that one cell (the binary, 2.2.28, is fine) and unrelated to any application change; it surfaced once GitHub's token format changed after the last green `main` run.

### Fix

The network tests clone **public** repositories and need no GitHub auth, so clear any configured token for that step:

- `COMPOSER_AUTH: "{}"` and an empty `GITHUB_TOKEN` (env-based sources),
- `composer config --global --unset github-oauth.github.com` (global `auth.json`).

This is version-agnostic and **keeps full Composer 2.2 coverage** — preferable to raising the `composer/composer` dev floor, since Composer never fixed this within the 2.2.x line and bumping past 2.2 would drop minimum-Composer-library coverage.