### PR TITLE
ci: adopt org reusable workflows, drop intra-org SHA pin

### DIFF
--- a/.github/workflows/auto-merge-deps.yml
+++ b/.github/workflows/auto-merge-deps.yml
@@ -1,73 +1,13 @@
-# Auto-merge dependency updates for repositories WITHOUT branch protection
-# Uses direct merge since --auto flag requires branch protection
 name: Auto-merge dependency PRs
 
 on:
-  pull_request_target:
-    types: [opened, synchronize, reopened]
+  pull_request:
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   auto-merge:
-    name: Auto-merge dependency PRs
-    runs-on: ubuntu-latest
-    # Use PR author login instead of github.actor to handle synchronize events
-    # when someone else pushes to the dependabot/renovate branch
-    if: github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.user.login == 'renovate[bot]'
-
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
-        with:
-          egress-policy: audit
-
-      - name: Dependabot metadata
-        id: metadata
-        if: github.event.pull_request.user.login == 'dependabot[bot]'
-        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
-        with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-
-      - name: Auto-approve PR
-        run: gh pr review --approve "$PR_URL"
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Wait for CI checks
-        run: |
-          echo "Waiting for CI checks to complete..."
-          for i in {1..60}; do
-            CHECKS=$(gh pr checks "$PR_URL" --json name,state \
-              --jq '[.[] | select(.name != "Auto-merge dependency PRs")]')
-
-            FAILED=$(echo "$CHECKS" | jq '[.[] | select(.state == "FAILURE" or .state == "ERROR")] | length')
-            PENDING=$(echo "$CHECKS" | jq '[.[] | select(.state == "PENDING" or .state == "QUEUED" or .state == "IN_PROGRESS")] | length')
-
-            if [ "$FAILED" != "0" ]; then
-              echo "Some checks failed, skipping merge"
-              exit 1
-            fi
-
-            if [ "$PENDING" = "0" ]; then
-              echo "All checks passed!"
-              exit 0
-            fi
-
-            echo "Waiting for $PENDING check(s)... (attempt $i/60)"
-            sleep 10
-          done
-          echo "Timeout waiting for checks"
-          exit 1
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Merge PR
-        run: gh pr merge --merge "$PR_URL"
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    uses: netresearch/.github/.github/workflows/auto-merge-deps.yml@main
+    permissions:
+      contents: write
+      pull-requests: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,78 +84,29 @@ jobs:
           composer config --global --unset github-oauth.github.com 2>/dev/null || true
           vendor/bin/phpunit --testdox
 
-  code-quality:
-    name: Code Quality
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2
-        with:
-          php-version: '8.4'
-          extensions: mbstring, xml, ctype, iconv
-          tools: php-cs-fixer
-          coverage: none
-
-      - name: Get Composer cache directory
-        id: composer-cache
-        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-
-      - name: Cache Composer packages
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-php-8.4-composer-${{ hashFiles('**/composer.json') }}
-          restore-keys: |
-            ${{ runner.os }}-php-8.4-composer-
-
-      - name: Install dependencies
-        run: composer install --prefer-dist --no-progress
-
-      - name: Run PHPStan
-        run: vendor/bin/phpstan analyse --error-format=github
-
-      - name: Run PHP-CS-Fixer (dry run)
-        run: php-cs-fixer fix --dry-run --diff --allow-risky=yes
-
-  coverage:
-    name: Code Coverage
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2
-        with:
-          php-version: '8.4'
-          extensions: mbstring, xml, ctype, iconv
-          coverage: xdebug
-
-      - name: Get Composer cache directory
-        id: composer-cache
-        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-
-      - name: Cache Composer packages
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-php-8.4-composer-${{ hashFiles('**/composer.json') }}
-          restore-keys: |
-            ${{ runner.os }}-php-8.4-composer-
-
-      - name: Install dependencies
-        run: composer install --prefer-dist --no-progress
-
-      - name: Run tests with coverage
-        run: vendor/bin/phpunit --coverage-text --coverage-clover=coverage.xml
-
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6
-        with:
-          files: ./coverage.xml
-          fail_ci_if_error: false
+  # PHPStan + PHP-CS-Fixer + PHPUnit-with-coverage + Codecov upload, via
+  # the org-standard reusable. The bespoke `tests` job above stays inline
+  # because the reusable matrices on PHP version only and cannot express
+  # this plugin's Symfony x Composer x prefer-lowest matrix or its
+  # network-test env. Folding these checks into the reusable removes the
+  # per-repo codecov-action reference that Renovate kept bumping.
+  checks:
+    name: Checks
+    uses: netresearch/.github/.github/workflows/php-ci.yml@main
+    permissions:
+      contents: read
+    with:
+      php-versions: '["8.4"]'
+      extensions: "mbstring, xml, ctype, iconv"
+      extra-tools: "php-cs-fixer"
+      coverage: "xdebug"
+      run-phpstan: true
+      phpstan-cmd: "vendor/bin/phpstan analyse --error-format=github"
+      run-cs-fixer: true
+      cs-fixer-cmd: "php-cs-fixer fix --dry-run --diff --allow-risky=yes"
+      run-phpunit: true
+      phpunit-cmd: "vendor/bin/phpunit --coverage-clover=coverage.xml"
+      upload-coverage-codecov: true
+      coverage-php-version: "8.4"
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ permissions: {}
 
 jobs:
   release:
-    uses: netresearch/.github/.github/workflows/release-composer-package.yml@444271f57885b6a0aa7844dfdb08c78229e8f2f1 # main
+    uses: netresearch/.github/.github/workflows/release-composer-package.yml@main
     permissions:
       contents: write
     with:


### PR DESCRIPTION
## What

Migrates this repo's CI to the org's reusable workflows and removes the SHA pin on an intra-org reusable.

- **`ci.yml`** — the `code-quality` (PHPStan + PHP-CS-Fixer) and `coverage` (PHPUnit + Codecov) jobs are folded into one `netresearch/.github/.github/workflows/php-ci.yml@main` caller. The bespoke `tests` job stays **inline** — the reusable matrices on PHP version only and cannot express this plugin's `PHP × Symfony × Composer × prefer-lowest` matrix or the `COMPOSER_AUTH`/github-oauth network-test env (see #77).
- **`auto-merge-deps.yml`** — replaces the inlined copy with the reusable `auto-merge-deps.yml` caller.
- **`release.yml`** — drops the SHA pin on the intra-org reusable (`release-composer-package.yml@444271f… # main` → `@main`).

## Why

Renovate was opening per-repo PRs for things that should be centrally managed:
- `codecov/codecov-action` bumps (#81, #82) — now gone, because the action lives once in `php-ci.yml`.
- `netresearch/.github` digest bump (#80) — intra-org reusable refs must track `@main`, never a pinned digest. With the pin removed, Renovate won't re-pin (`config:recommended` doesn't add digest pins).

Closes #80, #81, #82.

## Note on the inline `tests` job

It still pins `actions/checkout`, `setup-php`, `actions/cache` — Renovate will still bump *those* occasionally. This PR stops the **codecov** churn and the intra-org SHA pin; it does not (and cannot, without losing the bespoke matrix) eliminate every per-repo action bump.

## Validation

`yamllint` (org config), `actionlint`, `zizmor` clean on all three changed files. No intra-org SHA pins and no inline `codecov-action` remain.