### PR TITLE
fix: suppress always-true PHPStan narrowing on Composer tryComposer guard

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,3 +4,17 @@ parameters:
         - src
     excludePaths:
         - tests
+    ignoreErrors:
+        # `method_exists($this, 'tryComposer')` in CommandContextTrait is an
+        # intentional runtime guard: Composer 2.2 LTS has no tryComposer()
+        # (only the deprecated getComposer()), while >=2.3 does. PHPStan
+        # analyses against the *highest* resolved Composer (which has the
+        # method), so it narrows the check to always-true — once per command
+        # class that uses the trait. The guard must stay for the 2.2.*
+        # support path (composer.json: "2.2.*|^2.9"), so the finding is
+        # suppressed here. An inline @phpstan-ignore-next-line does not match
+        # all per-class trait analyses, hence the path-scoped ignore.
+        -
+            identifier: function.alreadyNarrowedType
+            path: src/Commands/CommandContextTrait.php
+            reportUnmatched: false

--- a/src/Commands/CommandContextTrait.php
+++ b/src/Commands/CommandContextTrait.php
@@ -29,7 +29,8 @@ trait CommandContextTrait
     {
         // tryComposer() was introduced in Composer 2.3; 2.2 LTS only has
         // the deprecated getComposer(). Resolve in a way that works on both.
-        /** @phpstan-ignore-next-line function.alreadyNarrowedType */
+        // (The always-true narrowing PHPStan reports here under Composer >=2.3
+        // is suppressed via phpstan.neon — see the ignoreErrors note there.)
         if (method_exists($this, 'tryComposer')) {
             $composer = $this->tryComposer();
         } else {


### PR DESCRIPTION
## Problem

`Code Quality` (PHPStan) is **red on `main`** under current dependency resolution — confirmed by re-running the last-green run ([26959408575](https://github.com/netresearch/composer-agent-skill-plugin/actions/runs/26959408575)). This is independent of any workflow change; it's no-committed-lockfile drift.

`CommandContextTrait::resolveContext()` guards `tryComposer()` (Composer ≥2.3) behind `method_exists($this, 'tryComposer')` so the deprecated `getComposer()` path still works on **Composer 2.2 LTS** — which `composer.json` explicitly supports (`"composer/composer": "2.2.*|^2.9"`, and the CI matrix tests 2.2). PHPStan analyses against the **highest** resolved Composer (2.10.1), where `tryComposer()` always exists, so it reports `function.alreadyNarrowedType` — **once per command class** that uses the trait (5 errors). The inline `@phpstan-ignore-next-line` does not match all per-class trait analyses, so it stopped suppressing them.

## Fix

- Move the suppression to a **path-scoped `ignoreErrors`** entry in `phpstan.neon` (identifier `function.alreadyNarrowedType`, `reportUnmatched: false`) — robust across the trait's per-class analyses.
- Drop the now-ineffective inline ignore.
- **The runtime guard is unchanged** and still required for the 2.2.* support path. This is a false-positive suppression, not a weakening — PHPStan can't see the 2.2 resolution where the method genuinely may be absent.

## Verification

Local, fresh highest resolution (`composer/composer` 2.10.1, PHPStan 2.2.2, PHP 8.5): **`[OK] No errors`** (was 5 errors before).

## Context

Surfaced while migrating CI to the org reusable `php-ci.yml` (#83) — that PR's `Checks` job runs PHPStan and inherited this pre-existing failure. This fix is split out so it stands on its own and unblocks `main`.