### PR TITLE
ci: align labeler.yml with php-module template

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -6,15 +6,7 @@ ci:
       - any-glob-to-any-file: ['.github/**/*', 'Makefile']
 dependencies:
   - changed-files:
-      - any-glob-to-any-file:
-          - 'composer.json'
-          - 'composer.lock'
-          - 'package.json'
-          - 'package-lock.json'
-          - 'bun.lock'
-          - 'bun.lockb'
-          - 'yarn.lock'
-          - '.devcontainer/**/*'
+      - any-glob-to-any-file: ['composer.json', 'composer.lock', 'package.json', 'package-lock.json', 'bun.lock', 'bun.lockb', 'yarn.lock', '.devcontainer/**/*']
 skill:
   - changed-files:
       - any-glob-to-any-file: ['skills/**/*', '.claude-plugin/**/*', 'plugin.json']


### PR DESCRIPTION
This repo uses the **php-module** template (`.github/template.yaml` → `template: php-module`), whose `labeler.yml` keeps the inline `dependencies` glob form. A prior drift-cleanup PR (#88) mistakenly synced it to the **skill** template's multi-line form, which then drifted against php-module. This restores the correct php-module `labeler.yml`.