### PR TITLE
ci: route the compatibility matrix through the shared php-ci reusable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,14 +7,21 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
+  # Compatibility matrix: PHP x Symfony x Composer host version, plus one
+  # `--prefer-lowest` cell that exercises the declared dependency minimums.
+  #
+  # The org-standard reusable matrices on PHP only, so the remaining
+  # dimensions live in the caller matrix and are handed to the reusable
+  # per cell:
+  #   * Composer host version -> `extra-tools: composer:<version>`
+  #     (shivammathur/setup-php keeps the LAST composer entry of the tools
+  #     list, so this overrides the reusable's always-on `composer:v2`)
+  #   * Symfony constraint + lowest-deps resolution -> `pre-install-cmd`
   tests:
-    name: PHP ${{ matrix.php }} - Symfony ${{ matrix.symfony }} - Composer ${{ matrix.composer }}${{ matrix.prefer-lowest && ' (lowest)' || '' }}
-    runs-on: ubuntu-latest
-
+    name: Symfony ${{ matrix.symfony }} - Composer ${{ matrix.composer }}${{ matrix.prefer-lowest && ' (lowest)' || '' }}
     strategy:
       fail-fast: false
       matrix:
@@ -28,68 +35,28 @@ jobs:
             symfony: '5.4.*'
             composer: '2.2'
             prefer-lowest: true
+    uses: netresearch/.github/.github/workflows/php-ci.yml@main
+    permissions:
+      contents: read
+    with:
+      php-versions: '["${{ matrix.php }}"]'
+      extensions: "mbstring, xml, ctype, iconv"
+      extra-tools: "composer:${{ matrix.composer }}"
+      coverage: "none"
+      pre-install-cmd: >-
+        composer require "symfony/yaml:${{ matrix.symfony }}" "symfony/console:${{ matrix.symfony }}" --no-update --no-interaction &&
+        composer update --prefer-dist --no-progress ${{ matrix.prefer-lowest && '--prefer-lowest --prefer-stable' || '' }}
+      run-phpstan: false
+      run-phpunit: true
+      # Runs the @group network tests, which clone PUBLIC repos and need no
+      # GitHub auth. Clear any configured token so the composer/composer
+      # 2.2.0 library (installed in the prefer-lowest cell) does not reject
+      # the modern GitHub token format with "github oauth token … contains
+      # invalid characters". The composer binary is unaffected — this only
+      # concerns the library instantiated by the tests.
+      phpunit-cmd: "composer config --global --unset github-oauth.github.com 2>/dev/null || true; COMPOSER_AUTH='{}' GITHUB_TOKEN='' vendor/bin/phpunit --testdox"
 
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
-        with:
-          php-version: ${{ matrix.php }}
-          tools: composer:${{ matrix.composer }}
-          extensions: mbstring, xml, ctype, iconv
-          coverage: none
-
-      - name: Validate composer.json
-        run: composer validate --strict
-
-      - name: Get Composer cache directory
-        id: composer-cache
-        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-
-      - name: Cache Composer packages
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-php-${{ matrix.php }}-symfony-${{ matrix.symfony }}-composer-${{ matrix.composer }}-${{ matrix.prefer-lowest && 'low' || 'high' }}-${{ hashFiles('**/composer.json') }}
-          restore-keys: |
-            ${{ runner.os }}-php-${{ matrix.php }}-symfony-${{ matrix.symfony }}-composer-${{ matrix.composer }}-
-            ${{ runner.os }}-php-${{ matrix.php }}-symfony-${{ matrix.symfony }}-
-            ${{ runner.os }}-php-${{ matrix.php }}-
-            ${{ runner.os }}-php-
-
-      - name: Install dependencies
-        env:
-          SYMFONY_VERSION: ${{ matrix.symfony }}
-          UPDATE_FLAGS: ${{ matrix.prefer-lowest && '--prefer-lowest --prefer-stable' || '' }}
-        run: |
-          composer require "symfony/yaml:${SYMFONY_VERSION}" "symfony/console:${SYMFONY_VERSION}" --no-update --no-interaction
-          # shellcheck disable=SC2086
-          composer update --prefer-dist --no-progress ${UPDATE_FLAGS}
-
-      - name: Run tests (incl. @group network — GitHub + git)
-        env:
-          # Set to 1 only in air-gapped environments; default runs live clone tests.
-          SKIP_NETWORK_TESTS: ${{ vars.SKIP_NETWORK_TESTS }}
-          # The @group network tests clone PUBLIC repos and need no GitHub auth.
-          # Clear any configured token so the composer/composer 2.2.0 library
-          # (installed in the prefer-lowest cell) does not reject the modern
-          # GitHub token format with "github oauth token … contains invalid
-          # characters". The composer binary is unaffected — this only concerns
-          # the library instantiated by the tests.
-          COMPOSER_AUTH: "{}"
-          GITHUB_TOKEN: ""
-        run: |
-          composer config --global --unset github-oauth.github.com 2>/dev/null || true
-          vendor/bin/phpunit --testdox
-
-  # PHPStan + PHP-CS-Fixer + PHPUnit-with-coverage + Codecov upload, via
-  # the org-standard reusable. The bespoke `tests` job above stays inline
-  # because the reusable matrices on PHP version only and cannot express
-  # this plugin's Symfony x Composer x prefer-lowest matrix or its
-  # network-test env. Folding these checks into the reusable removes the
-  # per-repo codecov-action reference that Renovate kept bumping.
+  # PHPStan + PHP-CS-Fixer + PHPUnit-with-coverage + Codecov upload.
   checks:
     name: Checks
     uses: netresearch/.github/.github/workflows/php-ci.yml@main


### PR DESCRIPTION
Brings `.github/workflows/ci.yml` to the shared CI standard: **zero step-level action `uses:`** — every job now calls `netresearch/.github/.github/workflows/php-ci.yml@main`.

The `checks` job already used the reusable. The `tests` compatibility matrix was still inline with `actions/checkout` + `shivammathur/setup-php` + `actions/cache`; it is now a matrixed caller of the same reusable.

## How the extra matrix dimensions survive

The reusable matrices on PHP only, so PHP × Symfony × Composer × prefer-lowest lives in the *caller* matrix and is handed to the reusable per cell:

| Dimension | Mechanism |
|---|---|
| PHP 8.4 / 8.5 | `php-versions: '["${{ matrix.php }}"]'` (single-element array per cell) |
| Composer host 2.2 / 2.9 | `extra-tools: "composer:${{ matrix.composer }}"` |
| Symfony 5.4 / 6.4 / 7.4 / 8.0 | `pre-install-cmd` → `composer require … --no-update` |
| `--prefer-lowest --prefer-stable` | `pre-install-cmd` → `composer update` with the flags |
| GitHub-auth clearing for the network tests | folded into `phpunit-cmd` |

On the Composer pin: `shivammathur/setup-php` builds the tools list with `filterList`, which drops every `composer*` entry and re-inserts **the last valid one** (`src/tools.ts:259-275` at the SHA the reusable pins). So `tools: composer:v2, composer:2.2` installs 2.2 — the reusable's always-on `composer:v2` does not win. The two-part form is also proven live: run 29786677729 logs `Added composer 2.2.29` / `Added composer 2.9.8` per cell.

## Preserved as functional requirements

- **All 17 cells** (16 base + the lowest-deps include) with identical PHP/Symfony/Composer coverage.
- **`--prefer-lowest --prefer-stable`** resolution for the minimums cell. The reusable runs `composer install`, which cannot express this, so `pre-install-cmd` does `require --no-update && composer update …`; the reusable's later `composer install` then just verifies the lock it wrote.
- **`COMPOSER_AUTH='{}'` / `GITHUB_TOKEN=''` / `composer config --global --unset github-oauth.github.com`** before PHPUnit. This is not cosmetic: it was added in fc9284e because the composer/composer **2.2.0 library** installed in the prefer-lowest cell rejects the modern GitHub token format. Moved verbatim into `phpunit-cmd`.
- **`composer validate --strict`** before install, and it still runs against the pristine `composer.json` (the reusable's validate step precedes `pre-install-cmd`).
- Workflow `name`, triggers (`push` main / `pull_request` main / `workflow_dispatch`), and `fail-fast: false`.

## Dropped as local quirks

- **`SKIP_NETWORK_TESTS: ${{ vars.SKIP_NETWORK_TESTS }}` passthrough.** The reusable has no generic env passthrough, and threading a repo variable into the `phpunit-cmd` string would defeat the reusable's deliberate "commands go through `env:` so callers can't break out of argument position" design. `gh api repos/netresearch/composer-agent-skill-plugin/actions/variables` returns `total_count: 0` — the variable does not exist, so today every cell already runs the `@group network` tests. Behaviour is unchanged; only the air-gap escape hatch is gone.
- **Fine-grained composer cache key** (`…-symfony-<v>-composer-<v>-<low|high>-…` plus four `restore-keys` tiers). The reusable keys on `runner.os + php + hashFiles(composer.json, composer.lock)`, so all Symfony/Composer cells of one PHP version share a cache entry. The composer files-cache is content-addressed by package+version, so sharing is safe — it costs some redundant downloads, not correctness.
- **Job check names change** from `PHP 8.4 - Symfony 5.4.* - Composer 2.2` to `Symfony 5.4.* - Composer 2.2 / PHP 8.4` (the reusable appends its own job name). No required status checks are configured on `main` — verified against both protection layers: `repos/…/rules/branches/main` (deletion, non_fast_forward, copilot_code_review only) and `repos/…/branches/main/protection` (no `required_status_checks` key). Nothing to re-point.

## Gained from the standard

- `step-security/harden-runner` egress auditing on every cell — the inline job had none.
- `persist-credentials: false` on checkout — the inline job left the token in `.git/config`.
- No more per-repo `actions/cache` / `actions/checkout` / `setup-php` SHA pins for Renovate to bump in this file.

## Proposals for the shared standard

1. **`php-ci.yml` needs a generic env passthrough** (e.g. an `env-json` / `test-env` input applied to the check steps). It is the only reason `SKIP_NETWORK_TESTS` was dropped, and any repo with env-gated tests will hit the same wall.
2. **`php-ci.yml` cannot express `--prefer-lowest`.** Its dependency step is hard-wired to `composer install`; lowest-deps resolution has to be smuggled through `pre-install-cmd`, after which the reusable's own `composer install` is a redundant no-op. A `dependency-versions: highest|lowest` input (the `ramsey/composer-install` vocabulary) would make this first-class.
3. **The cache key could optionally include a caller-supplied discriminator** so matrixed callers can keep per-cell cache entries instead of sharing one per PHP version.

## Verification

- `actionlint 1.7.12` on the changed workflow: exit 0, no findings.
- Every input used (`php-versions`, `extensions`, `extra-tools`, `coverage`, `pre-install-cmd`, `run-phpstan`, `run-phpunit`, `phpunit-cmd`) checked against `netresearch/.github` `main` — all exist with the assumed types.
- Caller job `permissions: contents: read` matches the called job's declared `permissions: contents: read` exactly; top-level is `permissions: {}`.
- `grep -c 'uses: actions/\|uses: shivammathur/'` on the new file: 0.
