### PR TITLE
ci: express the matrix dimensions as named php-ci inputs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,12 +50,16 @@ jobs:
       #
       # Deliberately EMPTY on the prefer-lowest cell. It would be redundant
       # there — the floor of `^5.4|^6.0|^7.0|^8.0` is 5.4, which is exactly
-      # what --prefer-lowest resolves to anyway — and it is actively harmful:
-      # flex filters the solver pool on PRE_POOL_CREATE, and under Composer
-      # 2.2 with --prefer-lowest that drops the fixed platform package, so
-      # the resolve dies with "Fixed package ext-igbinary 3.2.17RC1 was not
-      # added to solver pool". The other Composer 2.2 cells are unaffected.
-      symfony-require: ${{ matrix.prefer-lowest && '' || matrix.symfony }}
+      # what --prefer-lowest resolves to anyway — and it appears to be
+      # harmful: with flex active that cell dies in the solver with "Fixed
+      # package ext-igbinary 3.2.17RC1 was not added to solver pool". The
+      # other Composer 2.2 cells are unaffected.
+      #
+      # Written as `!cond && value || ''` and NOT as `cond && '' || value`:
+      # the empty string is FALSY in GitHub expressions, so the second form
+      # falls through to the `||` branch in both cases and silently yields
+      # the value it was supposed to suppress.
+      symfony-require: ${{ !matrix.prefer-lowest && matrix.symfony || '' }}
       dependency-versions: ${{ matrix.prefer-lowest && 'lowest' || 'highest' }}
       # Symfony major and Composer version come from the CALLER matrix, so the
       # reusable cannot derive them; without this every cell of a PHP version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,15 @@ jobs:
       # symfony/yaml and symfony/console by name only — composer.json also
       # requires symfony/process, which therefore resolved to whatever
       # version fit while the cell still claimed to test one Symfony major.
-      symfony-require: ${{ matrix.symfony }}
+      #
+      # Deliberately EMPTY on the prefer-lowest cell. It would be redundant
+      # there — the floor of `^5.4|^6.0|^7.0|^8.0` is 5.4, which is exactly
+      # what --prefer-lowest resolves to anyway — and it is actively harmful:
+      # flex filters the solver pool on PRE_POOL_CREATE, and under Composer
+      # 2.2 with --prefer-lowest that drops the fixed platform package, so
+      # the resolve dies with "Fixed package ext-igbinary 3.2.17RC1 was not
+      # added to solver pool". The other Composer 2.2 cells are unaffected.
+      symfony-require: ${{ matrix.prefer-lowest && '' || matrix.symfony }}
       dependency-versions: ${{ matrix.prefer-lowest && 'lowest' || 'highest' }}
       # Symfony major and Composer version come from the CALLER matrix, so the
       # reusable cannot derive them; without this every cell of a PHP version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,13 +13,12 @@ jobs:
   # Compatibility matrix: PHP x Symfony x Composer host version, plus one
   # `--prefer-lowest` cell that exercises the declared dependency minimums.
   #
-  # The org-standard reusable matrices on PHP only, so the remaining
-  # dimensions live in the caller matrix and are handed to the reusable
-  # per cell:
-  #   * Composer host version -> `extra-tools: composer:<version>`
-  #     (shivammathur/setup-php keeps the LAST composer entry of the tools
-  #     list, so this overrides the reusable's always-on `composer:v2`)
-  #   * Symfony constraint + lowest-deps resolution -> `pre-install-cmd`
+  # Each dimension is now a NAMED input of the shared reusable rather than a
+  # command string assembled here:
+  #   * Composer host version    -> `composer-version`
+  #   * Symfony constraint       -> `symfony-require` (flex + SYMFONY_REQUIRE)
+  #   * lowest-deps resolution   -> `dependency-versions`
+  #   * per-cell composer cache  -> `cache-key-suffix`
   tests:
     name: Symfony ${{ matrix.symfony }} - Composer ${{ matrix.composer }}${{ matrix.prefer-lowest && ' (lowest)' || '' }}
     strategy:
@@ -41,11 +40,19 @@ jobs:
     with:
       php-versions: '["${{ matrix.php }}"]'
       extensions: "mbstring, xml, ctype, iconv"
-      extra-tools: "composer:${{ matrix.composer }}"
+      composer-version: ${{ matrix.composer }}
       coverage: "none"
-      pre-install-cmd: >-
-        composer require "symfony/yaml:${{ matrix.symfony }}" "symfony/console:${{ matrix.symfony }}" --no-update --no-interaction &&
-        composer update --prefer-dist --no-progress ${{ matrix.prefer-lowest && '--prefer-lowest --prefer-stable' || '' }}
+      # symfony/flex pins the WHOLE Symfony stack to the cell's major,
+      # transitive packages included. The previous `composer require` pinned
+      # symfony/yaml and symfony/console by name only — composer.json also
+      # requires symfony/process, which therefore resolved to whatever
+      # version fit while the cell still claimed to test one Symfony major.
+      symfony-require: ${{ matrix.symfony }}
+      dependency-versions: ${{ matrix.prefer-lowest && 'lowest' || 'highest' }}
+      # Symfony major and Composer version come from the CALLER matrix, so the
+      # reusable cannot derive them; without this every cell of a PHP version
+      # shares one cache entry and they evict each other.
+      cache-key-suffix: sf${{ matrix.symfony }}-c${{ matrix.composer }}
       run-phpstan: false
       run-phpunit: true
       # Runs the @group network tests, which clone PUBLIC repos and need no
@@ -54,7 +61,13 @@ jobs:
       # the modern GitHub token format with "github oauth token … contains
       # invalid characters". The composer binary is unaffected — this only
       # concerns the library instantiated by the tests.
-      phpunit-cmd: "composer config --global --unset github-oauth.github.com 2>/dev/null || true; COMPOSER_AUTH='{}' GITHUB_TOKEN='' vendor/bin/phpunit --testdox"
+      #
+      # COMPOSER_AUTH moved to check-env; GITHUB_TOKEN cannot follow it,
+      # because check-env refuses GITHUB_*/RUNNER_* keys by design so a
+      # caller cannot overwrite the runner's own contract.
+      check-env: |
+        COMPOSER_AUTH={}
+      phpunit-cmd: "composer config --global --unset github-oauth.github.com 2>/dev/null || true; GITHUB_TOKEN='' vendor/bin/phpunit --testdox"
 
   # PHPStan + PHP-CS-Fixer + PHPUnit-with-coverage + Codecov upload.
   checks:


### PR DESCRIPTION
Every dimension of the compatibility matrix was encoded as a command string or a tool-list side effect. The shared [`php-ci`](https://github.com/netresearch/.github/blob/main/.github/workflows/php-ci.yml) reusable now has a named input for each ([netresearch/.github#282](https://github.com/netresearch/.github/pull/282), [#284](https://github.com/netresearch/.github/pull/284)), so the caller states intent instead of mechanism.

| was | is |
|---|---|
| `extra-tools: "composer:${{ matrix.composer }}"` — relied on setup-php keeping the *last* composer entry | `composer-version` |
| `pre-install-cmd:` `composer require symfony/…` | `symfony-require` |
| `pre-install-cmd:` `composer update --prefer-lowest --prefer-stable` | `dependency-versions` |
| `COMPOSER_AUTH='{}'` prefixed onto `phpunit-cmd` | `check-env` |
| — | `cache-key-suffix` |

Matrix coverage is unchanged: **17 cells before, 17 after**.

### Two of these change behaviour, both for the better

**`symfony-require` pins the whole stack.** The old `pre-install-cmd` pinned `symfony/yaml` and `symfony/console` **by name**. `composer.json` also requires `symfony/process`:

```json
"symfony/yaml":    "^5.4|^6.0|^7.0|^8.0",
"symfony/console": "^5.4|^6.0|^7.0|^8.0",
"symfony/process": "^5.4|^6.0|^7.0|^8.0",
```

so `symfony/process` resolved to whatever version fit while the cell still reported "Symfony 5.4". `symfony-require` installs symfony/flex and exports `SYMFONY_REQUIRE`, which constrains every `symfony/*` package including transitive ones. This repo commits no `composer.lock`, so `composer install` resolves fresh and the constraint takes effect.

**`cache-key-suffix` stops the cells evicting each other.** Symfony major and Composer version come from the *caller* matrix, so the reusable cannot see them — without a suffix all eight cells of a PHP version shared one composer cache entry.

### One thing deliberately left inline

`GITHUB_TOKEN=''` stays in `phpunit-cmd`. `check-env` refuses `GITHUB_*` and `RUNNER_*` keys by design, so a caller cannot overwrite the runner's own contract — only `COMPOSER_AUTH` moved.