### PR TITLE
ci: drop the deprecated GITLEAKS_LICENSE secret mapping

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,7 +1,8 @@
 name: Security
 
-# Aggregated security scans: secret scanning (gitleaks), dependency review on
-# PRs, and a composer audit (every PHP module ships a composer.json).
+# Aggregated security scans: secret scanning (betterleaks), workflow static
+# analysis (zizmor), dependency review on PRs, and a composer audit (every PHP
+# module ships a composer.json).
 #
 # Top-level `permissions: {}` denies everything by default; each reusable
 # caller job re-declares the exact union its reusable's jobs require, so the
@@ -22,8 +23,6 @@ jobs:
     permissions:
       contents: read
       security-events: write
-    secrets:
-      GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
 
   zizmor:
     uses: netresearch/.github/.github/workflows/zizmor.yml@main


### PR DESCRIPTION
Syncs the template change from netresearch/.github#330.

Secret scanning runs on **betterleaks**, which is OSS and needs no license.
The shared reusable declares `GITLEAKS_LICENSE` only for backwards
compatibility and **never reads it**, so forwarding a repo secret into it was
dead plumbing that widened the secret exposure surface for no benefit.

The file was byte-identical to the previous template revision before this
change, so the diff is exactly the removed `secrets:` mapping — no
repo-specific drift was touched. Required to keep `check-template-drift` green.
