### PR TITLE
docs: sync the scanner wording from the template

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,8 +1,13 @@
 name: Security
 
-# Aggregated security scans: secret scanning (betterleaks), workflow static
-# analysis (zizmor), dependency review on PRs, and a composer audit (every PHP
-# module ships a composer.json).
+# Aggregated security scans:
+#   gitleaks         — secret scanning. The job and the reusable keep the
+#                      historical `gitleaks` name; the scan itself runs
+#                      betterleaks, which is OSS and needs no license.
+#   zizmor           — static analysis of this repo's own workflows.
+#   dependency-review — on pull requests only.
+#   composer-audit   — `composer audit` AND an Opengrep SAST scan; the called
+#                      reusable runs both unless skip-opengrep is set.
 #
 # Top-level `permissions: {}` denies everything by default; each reusable
 # caller job re-declares the exact union its reusable's jobs require, so the

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -6,8 +6,9 @@ rules:
   unpinned-uses:
     config:
       policies:
-        # First-party reusable workflows track @main by policy and are
-        # never SHA-pinned, so fixes propagate to all consumers.
+        # First-party `uses:` — reusable workflows AND composite actions —
+        # track @main by policy and are never SHA-pinned, so a fix propagates
+        # to every consumer without a bump in dozens of repos.
         "netresearch/*": ref-pin
         # Everything else must be pinned to a full commit SHA.
         "*": hash-pin


### PR DESCRIPTION
Picks up the wording correction from netresearch/.github#334 so this repo stays byte-identical to its template.

Three things the previous comments got wrong:

- the header named **betterleaks** while the job and the reusable keep the historical `gitleaks` name — the name is deliberate (renaming breaks every caller that references the workflow path or pins the job in branch protection), and the header now says so
- it called the last job a **composer audit**, but the reusable also runs an **Opengrep SAST scan** — `skip-opengrep` defaults to `false`
- the zizmor comment said the exemption covers "reusable workflows", while `"netresearch/*": ref-pin` matches any first-party `uses:`, composite actions included

Comments only. No job, permission or trigger changes, and the file was byte-identical to the previous template revision before this sync — anything that had drifted was left alone and reported instead.
